### PR TITLE
Fix Scala 3 ProductTypesPlatform.ProductType.isPOJO

### DIFF
--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -6,7 +6,7 @@ import scala.collection.immutable.{ListMap, ListSet}
 
 trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
 
-  import quotes.*, quotes.reflect.{*, given}
+  import quotes.*, quotes.reflect.*
 
   protected object ProductType extends ProductTypesModule {
 


### PR DESCRIPTION
fixes scalalandio/chimney#758

I tried to find out where the issue happens. 

[https://github.com/scalalandio/chimney-macro-commons/blob/4b503945e26d74aafd33261012fc9d3a08020078/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala#L43-L47](url)


```scala
def isPOJO[A](implicit A: Type[A]): Boolean = {
      val sym = TypeRepr.of(using A).typeSymbol
      !A.isPrimitive && !(A <:< Type[String]) && sym.isClassDef && !sym.isAbstract &&
      publicPrimaryOrOnlyPublicConstructor(sym).isDefined
    }
```

specifically, when the symbol is a Type Alias, the `sym.isClassDef` will return false, while the `publicPrimaryOrOnlyPublicConstructor(sym)` will still return a non-empty result.

So the fix will be simple.

Is there any test suite to verify the fixing? Or am i supposed to test it with the main project (chimney)?