### PR TITLE
Use stable field ordering in Scala 3

### DIFF
--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -104,13 +104,10 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
             // because it's encoded in the method signature in TASTy/bytecode, unlike source Position.
             val ctorParamOrder: Map[String, Int] =
               paramListsOf(A, sym.primaryConstructor).flatten
-                .map(_.name)
+                .map(_.name.trim)
                 .zipWithIndex
                 .toMap
 
-            // Like sortedPublicUnique but uses constructor parameter index instead of source Position.
-            // Used for ConstructorArgVal fields so that position-based (tuple) matching is stable across
-            // compilation units where source positions are unavailable.
             def sortedPublicUniqueByCtorOrder(syms: List[Symbol]): ListSet[Symbol] =
               ListSet.from(
                 sanitize(syms.filter(isPublic))

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -108,10 +108,12 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
                 .zipWithIndex
                 .toMap
 
+            // Sort symbols by the order they appear in the constructor; if they don't appear in the constructor,
+            // sort by the order of definition
             def sortedPublicUniqueByCtorOrder(syms: List[Symbol]): ListSet[Symbol] =
               ListSet.from(
                 sanitize(syms.filter(isPublic))
-                  .sortBy(s => ctorParamOrder.getOrElse(s.name.trim, Int.MaxValue))
+                  .sortBy(s => ctorParamOrder.getOrElse(s.name.trim, Int.MaxValue) -> s)
               )
 
             // To distinct between vals defined in constructor and in body

--- a/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
+++ b/chimney-macro-commons/src/main/scala-3/io/scalaland/chimney/internal/compiletime/datatypes/ProductTypesPlatform.scala
@@ -100,19 +100,32 @@ trait ProductTypesPlatform extends ProductTypes { this: DefinitionsPlatform =>
                 .sortBy(_._2)
                 .map(_._1)
 
-            // Make sure that: we only use public definitions, output is sorted by the order of definition
-            def sortedPublicUnique(syms: List[Symbol]): ListSet[Symbol] =
-              ListSet.from(sanitize(syms.filter(isPublic)).sorted)
+            // Stable constructor parameter order from primaryConstructor.paramSymss — reliable across compilation units
+            // because it's encoded in the method signature in TASTy/bytecode, unlike source Position.
+            val ctorParamOrder: Map[String, Int] =
+              paramListsOf(A, sym.primaryConstructor).flatten
+                .map(_.name)
+                .zipWithIndex
+                .toMap
+
+            // Like sortedPublicUnique but uses constructor parameter index instead of source Position.
+            // Used for ConstructorArgVal fields so that position-based (tuple) matching is stable across
+            // compilation units where source positions are unavailable.
+            def sortedPublicUniqueByCtorOrder(syms: List[Symbol]): ListSet[Symbol] =
+              ListSet.from(
+                sanitize(syms.filter(isPublic))
+                  .sortBy(s => ctorParamOrder.getOrElse(s.name.trim, Int.MaxValue))
+              )
 
             // To distinct between vals defined in constructor and in body
             val isArg = sameNamedSymbolIn(paramListsOf(A, sym.primaryConstructor).flatten.filter(isPublic).toSet)
 
-            val caseFields = sortedPublicUnique(sym.caseFields)
+            val caseFields = sortedPublicUniqueByCtorOrder(sym.caseFields)
 
             // As silly as it looks: when I tried to get rid of caseFields and handle everything with fieldMembers
             // the result was really bad. It probably can be done, but it's error prone at best.
             val (argFields, bodyFields) =
-              sortedPublicUnique(sym.fieldMembers.filterNot(sameNamedSymbolIn(caseFields))).partition(isArg)
+              sortedPublicUniqueByCtorOrder(sym.fieldMembers.filterNot(sameNamedSymbolIn(caseFields))).partition(isArg)
 
             (caseFields ++ argFields, bodyFields)
           }


### PR DESCRIPTION
Tries to tackle https://github.com/scalalandio/chimney/issues/818.

Field ordering in `parseExtraction` was based on source Position (via Symbol's implicit ordering), which is unreliable when types are resolved across separate compilation units.

This change derives field order from primaryConstructor.paramSymss instead, which is stable across compilation units as it is encoded in the method signature in TASTy/bytecode. Fallbacks to previous symbol order.

I don't really know if I should create tests for this somewhere.
We did test these changes in the project that motivated https://github.com/scalalandio/chimney/issues/818 and it seems to work to the extent that it doesn't fail the compilation or tests 😅 but this was a non-deterministic issue, so...